### PR TITLE
Fix release url

### DIFF
--- a/vmagent.spec
+++ b/vmagent.spec
@@ -5,7 +5,7 @@ Summary: vmagent is a tiny but mighty agent which helps you collect metrics from
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmalert.spec
+++ b/vmalert.spec
@@ -5,7 +5,7 @@ Summary: vmalert executes a list of the given alerting or recording rules agains
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmauth.spec
+++ b/vmauth.spec
@@ -5,7 +5,7 @@ Summary: vmauth executes a list of the given alerting or recording rules against
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmbackup.spec
+++ b/vmbackup.spec
@@ -5,7 +5,7 @@ Summary: vmbackup creates VictoriaMetrics data backups from instant snapshots.
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
 
 Source0: LICENSE
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent, /usr/bin/echo, /usr/bin/chown

--- a/vmctl.spec
+++ b/vmctl.spec
@@ -5,7 +5,7 @@ Summary: VictoriaMetrics command-line tool
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
 
 Source0: LICENSE
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent, /usr/bin/echo, /usr/bin/chown

--- a/vminsert.spec
+++ b/vminsert.spec
@@ -5,7 +5,7 @@ Summary:  accepts the ingested data and spreads it among vmstorage nodes accordi
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-amd64-v%{version}-cluster.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}-cluster.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmrestore.spec
+++ b/vmrestore.spec
@@ -5,7 +5,7 @@ Summary: vmrestore restores data from backups created by vmbackup. VictoriaMetri
 
 Group:   Development Tools
 License: ASL 2.0
-URL:     https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-amd64-v%{version}.tar.gz
+URL:     https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/vmutils-linux-amd64-v%{version}.tar.gz
 
 Source0: LICENSE
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent, /usr/bin/echo, /usr/bin/chown

--- a/vmselect.spec
+++ b/vmselect.spec
@@ -5,7 +5,7 @@ Summary:  accepts the ingested data and spreads it among vmselect nodes accordin
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-amd64-v%{version}-cluster.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}-cluster.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf

--- a/vmsingle.spec
+++ b/vmsingle.spec
@@ -5,7 +5,7 @@ Summary: The best long-term remote storage for Prometheus
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-amd64-v%{version}.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}.tar.gz
 
 Source0: %{name}.service
 Source1: victoriametrics.conf

--- a/vmstorage.spec
+++ b/vmstorage.spec
@@ -5,7 +5,7 @@ Summary:  accepts the ingested data and spreads it among vmstorage nodes accordi
 
 Group:   Development Tools
 License: ASL 2.0
-URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-amd64-v%{version}-cluster.tar.gz
+URL: https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/v%{version}/victoria-metrics-linux-amd64-v%{version}-cluster.tar.gz
 
 Source0: %{name}.service
 Source1: %{name}.conf


### PR DESCRIPTION
Last release contains BUGFIX which breaks old release url convention:
`BUGFIX: consistently name binaries at releases page in the form $(APP_NAME)-$(GOOS)-$(GOARCH)-$(VERSION).tar.gz. For example, victoria-metrics-linux-amd64-v1.79.0.tar.gz. Previously the $(GOOS) part was missing in binaries for Linux.`

That's why last builds failed: https://copr.fedorainfracloud.org/coprs/antonpatsev/VictoriaMetrics/packages/